### PR TITLE
docs(ata): adicionando ata da reunião 1

### DIFF
--- a/docs/atas/ata1.md
+++ b/docs/atas/ata1.md
@@ -1,0 +1,65 @@
+# Ata 1
+
+## Identificação
+
+| Data | Horário de Início | Horário de Término | Local | Projeto | Redator |
+|:----:|:-----------------:|:------------------:|:-----:|:-------:|:-------:|
+|   04/09/2025   |          09:30         |         09:50            |   Sala de aula da FCTE    |     ligamagic    |     Angélica, Vera e Samuel    |
+
+## Participantes da reunião
+
+| Convocados | Presente (Sim/Não) | E-mail |
+|:----------:|:------------------:|:------:|
+| ANGELICA DA COSTA CAMPOS | Sim | angelicadacostacampos@gmail.com |
+| GUILHERME OLIVEIRA | Sim |  |
+| MARCELO DE ARAUJO LOPES | Sim |  |
+| RAISSA ANDRADE SILVEIRA | Sim |  |
+| SAMUEL NOGUEIRA CAETANO | Sim |  |
+| THIAGO VIRIATO ACCIOLY | Sim |  |
+| VERA LUCIA BEZERRA DA SILVA | Sim |  |
+
+## Pauta
+| Nº | Descrição |
+|:--:|:---------:|
+| 1 | Criação da GitPages |
+| 2 | Definição das páginas: Participantes, Cronograma, Apps analisados, App escolhido, Gravações das reuniões e atas |
+| 3 | Escolha das ferramentas |
+| 4 | Elaboração do cronograma |
+| 5 | Criação do Rich Picture do app escolhido |
+| 6 | Desenvolvimento e preenchimento do Heatmap |
+
+## Pendências Anteriores
+
+| Nº | Pendência | Responsável | Data |
+|:--:|:---------:|:-----------:|:----:|
+| - | - | - | - |
+
+## Assuntos Tratados
+
+| Nº | Descrição | Tipo¹ |
+|:--:|:---------:|:-----:|
+| 1 | Criação da GitPages (responsável: Samuel) | Decisão |
+| 2 | Criação das páginas: Participantes (Samuel), Cronograma, Apps analisados, App escolhido, Gravações de reuniões e atas | Definição |
+| 3 | Escolha das ferramentas | Decisão |
+| 4 | Criação do cronograma | Definição |
+| 5 | Criação do Rich Picture do app escolhido | Definição |
+| 6 | Heatmap – já em criação, precisa apenas ser preenchido | Pendência |
+
+
+## Próxima Reunião
+09/09/205 ás 19h
+
+## Compromissos
+
+| Nº | Compromissos | Responsável | Data |
+|:--:|:------------:|:-----------:|:----:|
+| 1 | Criar GitPages | Samuel | - |
+| 2 | Criar páginas (Participantes, Cronograma, Apps analisados, App escolhido, Gravações) | Samuel + Equipe | - |
+| 3 | Elaborar cronograma | Equipe | - |
+| 4 | Criar Rich Picture do app escolhido | Equipe | - |
+| 5 | Preencher Heatmap | Equipe | - |
+
+## Histórico de versão
+| Versão | Data | Descrição | Autor(es)	 | Revisor(es)	 |
+|:--:|:------------:|:-----------:|:----:| :----:|
+|  1.0  |       05/09/2025       |       Criação da Documentação	      |   Angélica   |      |

--- a/docs/atas/atapadrao.md
+++ b/docs/atas/atapadrao.md
@@ -76,3 +76,8 @@ Presente: Marcar somente as pessoas que participaram da reunião
 | Nº | Compromissos | Responsável | Data |
 |:--:|:------------:|:-----------:|:----:|
 |    |              |             |      |
+
+## Histórico de versão
+| Versão | Data | Descrição | Autor(es)	 | Revisor(es)	 |
+|:--:|:------------:|:-----------:|:----:| :----:|
+|  1.0  |       04/09/2025       |       Criação da Documentação	      |   Angélica   |      |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,8 @@ nav:
       - Apresentação 1: apresentacao/apresentacao1.md 
   - Atas: 
       - Ata Padão: atas/atapadrao.md
+      - Ata 1: atas/ata1.md
+
   - Planejamento:
       - Planejamento 1: planejamento/planejamento1.md
   - Verificação:


### PR DESCRIPTION
### Descrição

Este PR adiciona a ata da reunião 1, realizada em 04/09/2025, contendo:

- Identificação da reunião (data, horário, local, redator, participantes).
- Pauta com os tópicos discutidos.

- Assuntos tratados e decisões.

- Compromissos e responsáveis.

- Histórico de versão.